### PR TITLE
Bump jenkins core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.zeroturnaround.jenkins</groupId>
   <artifactId>build-flow-test-aggregator</artifactId>
-  <version>1.2-GD</version>
+  <version>1.2-1.GD</version>
   <packaging>hpi</packaging>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Test+Aggregator+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.554.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <name>Build flow test aggregator</name>


### PR DESCRIPTION
This change enable to build plugin using java 1.8 and unify building of plugins for CING.
It also implies, that from now this plugin is deployable only to newer jenkins (CING).